### PR TITLE
:bug: JWT 인증 로그아웃 버그 수정

### DIFF
--- a/src/main/java/com/example/gfup2/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/example/gfup2/domain/user/entity/RefreshToken.java
@@ -21,6 +21,7 @@ public class RefreshToken {
     @Column(columnDefinition = "text")
     private String refreshToken;
 
+    @Column(unique = true)
     private String accountEmail;
 
     public RefreshToken(String refreshToken, String emailId) {

--- a/src/main/java/com/example/gfup2/domain/user/entity/User.java
+++ b/src/main/java/com/example/gfup2/domain/user/entity/User.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/example/gfup2/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/gfup2/domain/user/repository/RefreshTokenRepository.java
@@ -20,4 +20,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @Modifying
     @Query("UPDATE RefreshToken r SET r.refreshToken = :newTokenValue WHERE r.accountEmail = :email")
     void updateTokenValueByEmail(@Param("email") String email, @Param("newTokenValue") String newTokenValue);
+
+    @Transactional
+    RefreshToken findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/example/gfup2/web/auth/jwt/jwtFilter.java
+++ b/src/main/java/com/example/gfup2/web/auth/jwt/jwtFilter.java
@@ -51,7 +51,7 @@ public class jwtFilter extends OncePerRequestFilter {
 
         if (accessToken != null && jwtUtil.isTokenValid(accessToken)) {
             authenticateWithToken(accessToken);
-        } else if (jwtUtil.refreshTokenValidation(refreshToken)) {
+        } else if (jwtUtil.isTokenValid(refreshToken) && jwtUtil.refreshTokenValidation(refreshToken)) {
             handleRefreshToken(refreshToken, response);
         } else {
             log.info("accessToken과 refreshToken 둘다 만료되었습니다.");

--- a/src/main/java/com/example/gfup2/web/auth/jwt/jwtFilter.java
+++ b/src/main/java/com/example/gfup2/web/auth/jwt/jwtFilter.java
@@ -42,7 +42,7 @@ public class jwtFilter extends OncePerRequestFilter {
     }
 
     private boolean isAuthenticationRequired(String uri) {
-        return uri.equals("/auth/signup") || uri.equals("/auth/signin");
+        return uri.equals("/auth/signup") || uri.equals("/auth/signin") || uri.equals("/auth/logout");
     }
 
     private void handleAuthentication(HttpServletRequest request, HttpServletResponse response) {

--- a/src/main/java/com/example/gfup2/web/user/service/UserService.java
+++ b/src/main/java/com/example/gfup2/web/user/service/UserService.java
@@ -54,9 +54,12 @@ public class UserService {
             //토큰 발급
             TokenDto tokenDto = jwtUtil.generateToken(user.getEmailId());
 
-            RefreshToken refreshToken = new RefreshToken(tokenDto.getRefreshToken(), user.getEmailId());
-            refreshTokenRepository.save(refreshToken);
-
+            if(refreshTokenRepository.findByAccountEmail(user.getEmailId()).isPresent()) {
+                refreshTokenRepository.updateTokenValueByEmail(user.getEmailId(), tokenDto.getRefreshToken());
+            } else {
+                RefreshToken refreshToken = new RefreshToken(tokenDto.getRefreshToken(), user.getEmailId());
+                refreshTokenRepository.save(refreshToken);
+            }
 
             return tokenDto;
         }
@@ -65,7 +68,7 @@ public class UserService {
     }
 
     public ResponseEntity<String> logoutUser(String refreshToken) {
-        if(refreshToken != null) {
+        if(refreshTokenRepository.findByRefreshToken(refreshToken) != null) {
             refreshTokenRepository.deleteByRefreshToken(refreshToken);
             return ResponseEntity.ok().body("Logged out successfully");
         }


### PR DESCRIPTION
로그아웃 시에 refreshToken관련 오류가 있었어용.
- db에 동일한 id의 refreshToken이 여러개 추가되는 현상 
- 로그아웃 시에 필터에서 다시 토큰을 발급해서 넘기는 현상

-> 오류 해결완료
- 필터에서 /auth/logout 경로는 예외처리로 통과
- 로그인, 로그아웃 시에 db에 동일한 데이터가 있는지 확인하는 기능 추가